### PR TITLE
48 - Fix edge case with .sublime-project file not being in the same main folder

### DIFF
--- a/src/libs/util.py
+++ b/src/libs/util.py
@@ -635,17 +635,18 @@ def is_project_open(project):
 def is_javascript_project():
   project_file_name = sublime.active_window().project_file_name()
   project_dir_name = ""
-  if project_file_name :
+  if project_file_name:
     project_dir_name = os.path.dirname(project_file_name)
     settings_dir_name = os.path.join(project_dir_name, PROJECT_SETTINGS_FOLDER_NAME)
     return os.path.isdir(settings_dir_name)
-  else :
-    # try to look at window.folders()
-    folders = sublime.active_window().folders()   
-    if len(folders) > 0:
-      folders = folders[0]
-      settings_dir_name = os.path.join(folders, PROJECT_SETTINGS_FOLDER_NAME)
-      return os.path.isdir(settings_dir_name)
+
+  # If not found at the location of the .sublime-project file, try to look in the open folders.
+  folders = sublime.active_window().folders()
+  if len(folders) > 0:
+    folders = folders[0]
+    settings_dir_name = os.path.join(folders, PROJECT_SETTINGS_FOLDER_NAME)
+    return os.path.isdir(settings_dir_name)
+
   return False
 
 def is_type_javascript_project(type):

--- a/src/libs/util.py
+++ b/src/libs/util.py
@@ -638,14 +638,16 @@ def is_javascript_project():
   if project_file_name:
     project_dir_name = os.path.dirname(project_file_name)
     settings_dir_name = os.path.join(project_dir_name, PROJECT_SETTINGS_FOLDER_NAME)
-    return os.path.isdir(settings_dir_name)
+    if os.path.isdir(settings_dir_name):
+      return True
 
   # If not found at the location of the .sublime-project file, try to look in the open folders.
   folders = sublime.active_window().folders()
   if len(folders) > 0:
     folders = folders[0]
     settings_dir_name = os.path.join(folders, PROJECT_SETTINGS_FOLDER_NAME)
-    return os.path.isdir(settings_dir_name)
+    if os.path.isdir(settings_dir_name):
+      return True
 
   return False
 


### PR DESCRIPTION
Fixes an issue presented in #48.

If the `.sublime-project` file is not present in the same folder as the project files themselves, the plugin will not auto-discover the `.je-project-settings` folder correctly.

This PR allows the `is_javascript_project` method to fall back to active window folders detection when a JavaScript project settings folder is not found in the same place as the `.sublime-project` file.

The test suite passed successfully.