### PR TITLE
Add path support for the fish shell

### DIFF
--- a/main.py
+++ b/main.py
@@ -114,9 +114,9 @@ fixPathOriginalEnv = {}
 def getSysPath():
   command = ""
   if platform.system() == "Darwin":
-    command = "TERM=ansi CLICOLOR=\"\" SUBLIME=1 /usr/bin/login -fqpl $USER $SHELL -l -c 'TERM=ansi CLICOLOR=\"\" SUBLIME=1 printf \"%s\" \"$PATH\"'"
+    command = "env TERM=ansi CLICOLOR=\"\" SUBLIME=1 /usr/bin/login -fqpl $USER $SHELL -l -c 'TERM=ansi CLICOLOR=\"\" SUBLIME=1 printf \"%s\" \"$PATH\"'"
   elif platform.system() == "Linux":
-    command = "TERM=ansi CLICOLOR=\"\" SUBLIME=1 $SHELL --login -c 'TERM=ansi CLICOLOR=\"\" printf \"%s\" $PATH'"
+    command = "env TERM=ansi CLICOLOR=\"\" SUBLIME=1 $SHELL --login -c 'TERM=ansi CLICOLOR=\"\" printf \"%s\" $PATH'"
   else:
     return ""
 


### PR DESCRIPTION
This pull request fixes an issue with the `fish` shell when determining the system path, the following error would appear in the console:

```
Traceback (most recent call last):
  File "/Users/dave/Library/Application Support/Sublime Text 3/Packages/JavaScript Enhancements/main.py", line 140, in fixPath
    currSysPath = getSysPath()
  File "/Users/dave/Library/Application Support/Sublime Text 3/Packages/JavaScript Enhancements/main.py", line 129, in getSysPath
    sysPath = sysPath.splitlines()[-1]
IndexError: list index out of range
``` 

Prepending the command with the `env` command fixes the issue, it has been tested with the `fish`, `zsh` and `bash` shells.